### PR TITLE
added checkOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Automatically adds code to Swift Package Manager projects to run unit tests on L
 Usage: linuxmain-generator
   -o,--overwrite:
       Replace <test directory>/LinuxMain.swift if it already exists.
+  -c,--checkOnly:
+      Do not modify any file. Exits with 0 if test cases are in sync, otherwise exits with 1.
   --testdir <test directory>:
       The path to the directory with the unit tests. Default = 'Tests'.
   <directory>:

--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ Usage: linuxmain-generator
 ## Installation
 
 ### Homebrew
+
 ```bash
-brew install kareman/repo/linuxmain-generator
+brew tap valeriomazzeo/linuxmain-generator
+brew install linuxmain-generator
 ```
 
 ### Manual
+
 ```bash
-git clone https://github.com/kareman/linuxmain-generator
-cd linuxmain-generator
+git clone https://github.com/valeriomazzeo/homebrew-linuxmain-generator
+cd homebrew-linuxmain-generator
 swift build -c release
 cp .build/release/linuxmain-generator /usr/local/bin/linuxmain-generator
 ```
@@ -35,5 +38,4 @@ cp .build/release/linuxmain-generator /usr/local/bin/linuxmain-generator
 
 Released under the MIT License (MIT), http://opensource.org/licenses/MIT
 
-Kåre Morstøl, [NotTooBad Software](http://nottoobadsoftware.com)
-
+Originally forked from https://github.com/kareman/linuxmain-generator

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -5,6 +5,20 @@ import FileSmith
 
 let indentation = "\t"
 
+extension Dictionary {
+
+    mutating func merge(with dictionary: Dictionary) {
+        dictionary.forEach { self[$0] = $1 }
+    }
+
+    func merged(with dictionary: Dictionary) -> Dictionary {
+        var dict = self
+        dict.merge(with: dictionary)
+
+        return dict
+    }
+}
+
 extension String {
 	func subString(between before: String, and after: String) -> String? {
 		guard let start = range(of: before)?.upperBound,
@@ -14,31 +28,68 @@ extension String {
 	}
 }
 
-typealias TestClass = (classname: String, funcs: [String])
+typealias TestClasses = [String: Set<String>]
 
-func getTestClasses(_ input: ReadableFile) -> [TestClass] {
-	var result = [TestClass]()
+func getTestClasses(_ input: ReadableFile) -> TestClasses {
+	var result = TestClasses()
+
+    var classname: String?
+
 	for line in input.lines() {
-		if line.contains("XCTestCase"),
-			let classname = line.subString(between: "class", and: ":")?.trimmingCharacters(in: .whitespaces) {
 
-			result.append((classname,[]))
+		if line.contains("XCTestCase"), let name = line.subString(between: "class", and: ":")?.trimmingCharacters(in: .whitespaces) {
 
-		} else if var currentclass = result.last,
+            classname = name
+			result[name] = Set()
+
+		} else if let currentclass = classname,
+            var currentClassFuncs = result[currentclass],
+            !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") && !line.trimmingCharacters(in: .whitespaces).hasPrefix("/*"),
 			let newfunc = line.subString(between: "func ", and: "()")?.trimmingCharacters(in: .whitespaces),
 			newfunc.hasPrefix("test") {
 
-			currentclass.funcs.append(newfunc)
-			result[result.endIndex-1] = currentclass
+			currentClassFuncs.insert(newfunc)
+			result[currentclass] = currentClassFuncs
 		}
 	}
 	return result
 }
 
-func makeAllTests(_ testclass: TestClass) -> String {
-	var result = "\nextension " + testclass.classname + " {\n"
+func getTestClassesFromAllTests(_ input: ReadableFile) -> TestClasses {
+    var result = TestClasses()
+
+    var classname: String?
+
+    var isAllTests = false
+
+    for line in input.lines() {
+
+        if line.contains("XCTestCase"), let name = line.subString(between: "class", and: ":")?.trimmingCharacters(in: .whitespaces) {
+
+            classname = name
+            result[name] = Set()
+            isAllTests = false
+
+        } else if !isAllTests && line.contains("static let allTests = [") {
+            isAllTests = true
+
+        } else if let currentclass = classname,
+            var currentClassFuncs = result[currentclass],
+            !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") && !line.trimmingCharacters(in: .whitespaces).hasPrefix("/*"),
+            let newfunc = line.subString(between: "\",", and: ")")?.trimmingCharacters(in: .whitespaces),
+            newfunc.hasPrefix("test") {
+
+            currentClassFuncs.insert(newfunc)
+            result[currentclass] = currentClassFuncs
+        }
+    }
+    return result
+}
+
+func makeAllTests(classname: String, funcs: Set<String>) -> String {
+	var result = "\nextension " + classname + " {\n"
 	result += indentation + "public static var allTests = [\n"
-	result += testclass.funcs.map { testfunc in
+	result += funcs.map { testfunc in
 		indentation + indentation + "(\"\(testfunc)\", \(testfunc)),\n"
 		}.joined()
 	result += indentation + indentation + "]\n"
@@ -53,9 +104,26 @@ func addAllTests(tofile path: FilePath) throws -> [String] {
 
 	let file = try path.edit()
 	testclasses.map(makeAllTests).forEach(file.write)
-	let names = testclasses.map {$0.classname}
+	let names = testclasses.map {$0.key}
 	print("+ \(path): Added 'allTests' to \(names.joined(separator: ", ")).")
 	return names
+}
+
+func getTestClassnamesLinuxMainDotSwift(testdir: Directory) throws -> Set<String> {
+    var result = Set<String>()
+
+    let input = try testdir.open(file: "LinuxMain.swift")
+
+    for line in input.lines() {
+
+        if line.contains("testCase("), let name = line.subString(between: "testCase(", and: ".allTests)")?.trimmingCharacters(in: .whitespaces) {
+
+            // We don't have a way (yet) to know to which package a test class belongs,
+            // so we are going to strip eventual namespacing for the time being.
+            result.insert(name.components(separatedBy: ".").last ?? name)
+        }
+    }
+    return result
 }
 
 func makeLinuxMainDotSwift(testdir: Directory, classnames: [String]) throws {
@@ -74,8 +142,69 @@ func makeLinuxMainDotSwift(testdir: Directory, classnames: [String]) throws {
 	print("+ \(testdir.path)/LinuxMain.swift")
 }
 
+func testClassesDifference(_ parsed: TestClasses, declared: TestClasses) -> TestClasses {
+    var result = TestClasses()
+
+    for testClass in parsed {
+        let funcs = declared[testClass.key] ?? Set()
+        let missingTests = testClass.value.subtracting(funcs)
+
+        if !missingTests.isEmpty {
+            result[testClass.key] = missingTests
+        }
+    }
+
+    return result
+}
+
+func checkOnly(testDir: Directory, testFiles: [FilePath]) throws -> Bool {
+
+    // Check for missing tests declaration
+    var missingTests = TestClasses()
+
+    var allTestClassNames = Set<String>()
+
+    for testFile in testFiles {
+        let testClasses = getTestClasses(try testFile.open())
+        let allTestsTestClasses = getTestClassesFromAllTests(try testFile.open())
+
+        missingTests.merge(with: testClassesDifference(testClasses, declared: allTestsTestClasses))
+
+        allTestClassNames.formUnion(Set(testClasses.keys))
+    }
+
+    // Check for missing test classes in LinuxMain.swift
+    let missingLinuxDotMainClassNames = allTestClassNames.subtracting(try getTestClassnamesLinuxMainDotSwift(testdir: testDir))
+
+    guard missingTests.isEmpty, missingLinuxDotMainClassNames.isEmpty else {
+
+        if !missingLinuxDotMainClassNames.isEmpty {
+            WritableFile.stderror.print("LinuxMain.swift testCase declarations missing:\n")
+            for testCase in missingLinuxDotMainClassNames {
+                WritableFile.stderror.print(testCase)
+            }
+            WritableFile.stderror.print("")
+        }
+
+        if !missingTests.isEmpty {
+            WritableFile.stderror.print("Tests declaration missing:\n")
+            for testClass in missingTests {
+                WritableFile.stderror.print(testClass.key)
+                for test in testClass.value {
+                    WritableFile.stderror.print("\t\(test)")
+                }
+            }
+        }
+
+        return false
+    }
+
+    return true
+}
+
 let arguments = Moderator(description: "Automatically add code to Swift Package Manager projects to run unit tests on Linux.")
 let overwrite = arguments.add(.option("o","overwrite", description: "Replace <test directory>/LinuxMain.swift if it already exists."))
+let checkOnly = arguments.add(.option("c","checkOnly", description: "Do not modify any file. Exits with 0 if test cases are in sync, otherwise exits with 1."))
 let testdirarg = arguments.add(Argument<String?>
 	.optionWithValue("testdir", name: "test directory", description: "The path to the directory with the unit tests.")
 	.default("Tests"))
@@ -92,7 +221,8 @@ do {
 	try arguments.parse(strict: true)
 
 	let testdir = try Directory(open: testdirarg.value)
-	if !overwrite.value && testdir.contains("LinuxMain.swift") {
+
+	if !checkOnly.value && !overwrite.value && testdir.contains("LinuxMain.swift") {
 		throw ArgumentError(errormessage: "\(testdir.path)/LinuxMain.swift already exists. Use -o/--overwrite to replace it.")
 	}
 
@@ -101,6 +231,12 @@ do {
 		WritableFile.stderror.print("Could not find any .swift files under \"\(testdir.path)/*/\".")
 		exit(EXIT_FAILURE)
 	}
+
+    guard !checkOnly.value else {
+        // Perform only a check then exit
+        exit(try checkOnly(testDir: testdir, testFiles: testfiles) ? 0 : EXIT_FAILURE)
+    }
+
 	let classnames = try testfiles.flatMap(addAllTests)
 	try makeLinuxMainDotSwift(testdir: testdir, classnames: classnames)
 } catch {

--- a/formula.rb
+++ b/formula.rb
@@ -1,0 +1,12 @@
+class LinuxmainGenerator < Formula
+  desc "Shell command to keep SPM tests in sync on OSX and Linux."
+  homepage "https://github.com/valeriomazzeo/linuxmain-generator"
+  url "https://github.com/valeriomazzeo/linuxmain-generator/archive/0.2.0.tar.gz"
+  sha256 "84a7a29ef8680426d52591631610b683c853910c49532ad17d7101bd35ed207b"
+
+  def install
+    ENV["CC"] = ""
+    system "swift", "build", "-c", "release"
+    bin.install ".build/release/linuxmain-generator"
+  end
+end

--- a/formula.rb
+++ b/formula.rb
@@ -1,8 +1,8 @@
 class LinuxmainGenerator < Formula
   desc "Shell command to keep SPM tests in sync on OSX and Linux."
   homepage "https://github.com/valeriomazzeo/linuxmain-generator"
-  url "https://github.com/valeriomazzeo/linuxmain-generator/archive/0.2.0.tar.gz"
-  sha256 "84a7a29ef8680426d52591631610b683c853910c49532ad17d7101bd35ed207b"
+  url "https://github.com/valeriomazzeo/homebrew-linuxmain-generator/archive/0.2.0.tar.gz"
+  sha256 "50e0ec57794191b830fd2c69aff8bbfd65989d0c837809b68035bcafd9e8da09"
 
   def install
     ENV["CC"] = ""

--- a/linuxmain-generator.rb
+++ b/linuxmain-generator.rb
@@ -2,6 +2,7 @@ class LinuxmainGenerator < Formula
   desc "Shell command to keep SPM tests in sync on OSX and Linux."
   homepage "https://github.com/valeriomazzeo/linuxmain-generator"
   url "https://github.com/valeriomazzeo/homebrew-linuxmain-generator/archive/0.2.0.tar.gz"
+  version "0.2.0"
   sha256 "50e0ec57794191b830fd2c69aff8bbfd65989d0c837809b68035bcafd9e8da09"
 
   def install


### PR DESCRIPTION
This pull request adds a `-c`, `checkOnly` option to linuxmain-generator.

When this argument is passed the script works in a read-only mode which is particularly useful for adding it as a check on CI systems.

In order to achieve this I had to get some kind of diffs so I refactored the code a little bit to use Sets.
I think with these changes you could in the future be able to achieve what has been proposed in #1.

I apologise if it's messy, but don't have the time to rewrite it with tests and everything.

Example output:

```
LinuxMain.swift testCase declarations missing:

AnyResponderTests
JSONResourceSerializerTests
VoidResponderTests
JSONErrorSerializerTests
StatusCodeValidatorTests
StringResourceSerializerTests

Tests declaration missing:

ScopeTests
	testRawValueWithNilOptions
Program ended with exit code: 1
```

cc/ @kareman